### PR TITLE
Bug fix, screen will be unclickble after toast(s)

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -255,6 +255,14 @@ export const app = {
         document.querySelector('#toastContainer').appendChild(toast);
         feather.replace();
         $(`[data-toast="toastIndex${this.toastIndex}"]`).toast('show');
+		
+		//removal of toast div
+		let secondTime = false;
+		toast.onanimationend = function () {
+			if (secondTime){
+				document.querySelector('#toastContainer').removeChild(toast)
+			} else { secondTime = true;}
+		};
     },
     
     errorText(element, content) {


### PR DESCRIPTION
Bug fix screen will be unclickble after toast because the toast div will be still n screen after the toast has ended. This prevented you couldn't click on anything the div was covering. So after the second animation had ended of the div (first popup, second popdown), I added the removal of the div so the divs wouldn't stack on each other.
I came across this bug at a screen resolution of 1024 x 600.